### PR TITLE
Map external services

### DIFF
--- a/appmap.yml
+++ b/appmap.yml
@@ -1,6 +1,6 @@
 name: spring-petclinic
 packages:
   - path: org.springframework.samples.petclinic
-    shallow: true
+    shallow: false
 language: java
 appmap_dir: target/appmap

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-httpclient</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,5 @@ logging.level.org.springframework=INFO
 
 # Maximum time static resources should be cached
 spring.web.resources.cache.cachecontrol.max-age=12h
+
+feign.httpclient.enabled=true


### PR DESCRIPTION
Use new features of `appmap-java` to capture calls to external services.

New version the Java agent: [appmap-1.17.0.jar.gz](https://github.com/manojvsp12/spring-petclinic-feign-db-demo/files/11230889/appmap-1.17.0.jar.gz)

When you run the app, you'll need to include the arguments `-javaagent:appmap-1.17.0.jar -Dappmap.record.getters=true`. The latter argument (not yet documented) tells `appmap-java` to capture calls to methods that start with `get`. Because getters are so common in Java, they're not recorded by default. Setting `appmap.record.getters=true` will cause them to be included.

With these changes, you should see an AppMap that looks like this:
<img width="1842" alt="image" src="https://user-images.githubusercontent.com/4212483/232001478-e5dd7ec0-6fa6-4f45-aefc-481fffc09684.png">
